### PR TITLE
fix: change docker compose volume name from dau

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       timeout: 5s
       retries: 10
     volumes:
-      - ~/data/dau/postgres:/var/lib/postgresql/data
+      - ~/data/viral-spiral/postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
 


### PR DESCRIPTION
This PR updates the volume name within the docker-compose file. The name was "data/dau". Changed it to "data/viral-spiral".