### PR TITLE
fix: bias assignment for 3 players and less

### DIFF
--- a/lib/viral_spiral/entity/room.ex
+++ b/lib/viral_spiral/entity/room.ex
@@ -123,7 +123,7 @@ defmodule ViralSpiral.Entity.Room do
 
     room_communities =
       case player_count do
-        x when x <= 3 -> Enum.shuffle(communities) |> Enum.take(2)
+        x when x <= 2 -> Enum.shuffle(communities) |> Enum.take(2)
         _ -> communities
       end
 

--- a/lib/viral_spiral/room/card_draw.ex
+++ b/lib/viral_spiral/room/card_draw.ex
@@ -93,7 +93,7 @@ defmodule ViralSpiral.Room.CardDraw do
   end
 
   @identities [:red, :blue, :yellow]
-  def assign_player_identity(names) do
+  def assign_player_identity(names, room_communities) do
     total = length(names)
     identity_count = length(@identities)
 
@@ -101,6 +101,10 @@ defmodule ViralSpiral.Room.CardDraw do
       case total do
         ^identity_count ->
           Enum.shuffle(@identities)
+
+        2 ->
+          # Room communities are always 2 in case of 2 players.
+          Enum.shuffle(room_communities)
 
         _ ->
           base_count = div(total, identity_count)

--- a/lib/viral_spiral/room/card_draw.ex
+++ b/lib/viral_spiral/room/card_draw.ex
@@ -99,9 +99,6 @@ defmodule ViralSpiral.Room.CardDraw do
 
     final_identities =
       case total do
-        ^identity_count ->
-          Enum.shuffle(@identities)
-
         2 ->
           # Room communities are always 2 in case of 2 players.
           Enum.shuffle(room_communities)
@@ -111,7 +108,8 @@ defmodule ViralSpiral.Room.CardDraw do
           remainder = rem(total, identity_count)
 
           evenly_dist =
-            @identities |> Enum.flat_map(fn color -> List.duplicate(color, base_count) end)
+            Enum.shuffle(@identities)
+            |> Enum.flat_map(fn color -> List.duplicate(color, base_count) end)
 
           extra_dist =
             if remainder > 0 do

--- a/lib/viral_spiral/room/state.ex
+++ b/lib/viral_spiral/room/state.ex
@@ -64,13 +64,14 @@ defmodule ViralSpiral.Room.State do
 
   def setup(%State{} = state) do
     room = state.room
+    room_communities = room.communities
 
     if length(room.unjoined_players) == 0,
       do: raise("Can not initialize state when no players have joined")
 
     players =
       room.unjoined_players
-      |> CardDraw.assign_player_identity()
+      |> CardDraw.assign_player_identity(room_communities)
       |> Enum.map(fn {name, identity} ->
         Factory.new_player_for_room(room, identity) |> Player.set_name(name)
       end)

--- a/test/viral_spiral/room/card_draw_test.exs
+++ b/test/viral_spiral/room/card_draw_test.exs
@@ -197,14 +197,21 @@ defmodule ViralSpiral.Room.CardDrawTest do
   @identities [:red, :blue, :yellow]
   test "assign_player_identity" do
     for _ <- 1..1000 do
-      for n <- 3..12 do
+      for n <- 2..12 do
         # Generate dummy names
         names = Enum.map(1..n, &"player_#{&1}")
 
-        # assign_player_identity function accepts room_communities as second argument that is only used in
-        # case of 2 players. Here, as the test is for 3 or more players, the second argument passed is nil
-        result = CardDraw.assign_player_identity(names, nil)
+        # Pick room communities only for the 2-player case; otherwise use all identities
+        room_communities =
+          if n == 2 do
+            [:red, :blue]
+          else
+            @identities
+          end
 
+        result = CardDraw.assign_player_identity(names, room_communities)
+
+        # length matches
         assert length(result) == length(names)
 
         # All names are present
@@ -215,54 +222,23 @@ defmodule ViralSpiral.Room.CardDrawTest do
         identities = Enum.map(result, &elem(&1, 1))
         assert Enum.all?(identities, &(&1 in @identities))
 
-        # At least one of each identity is used
-        assert Enum.any?(identities, &(&1 == :red))
-        assert Enum.any?(identities, &(&1 == :blue))
-        assert Enum.any?(identities, &(&1 == :yellow))
+        if n == 2 do
+          # For two players, you must get exactly the two you passed in
+          assert Enum.sort(identities) == Enum.sort(room_communities)
+        else
+          # At least one of each identity is used
+          assert Enum.any?(identities, &(&1 == :red))
+          assert Enum.any?(identities, &(&1 == :blue))
+          assert Enum.any?(identities, &(&1 == :yellow))
 
-        # Check that no identity appears more than ceil(n / 3) + 1 times
-        max_allowed = div(n, 3) + 1
-        identity_counts = Enum.frequencies(identities)
+          # Check that no identity appears more than ceil(n / 3) + 1 times
+          max_allowed = div(length(names), 3) + 1
+          identity_counts = Enum.frequencies(identities)
 
-        for {color, count} <- identity_counts do
-          assert count <= max_allowed
+          for {_color, count} <- identity_counts do
+            assert count <= max_allowed
+          end
         end
-      end
-    end
-  end
-
-  test "assign_player_identity_for_2_players" do
-    # Test with different combinations of 2 colors
-    test_communities = [
-      [:red, :blue],
-      [:red, :yellow],
-      [:blue, :yellow]
-    ]
-
-    for communities <- test_communities do
-      names = ["player_1", "player_2"]
-
-      result = CardDraw.assign_player_identity(names, communities)
-
-      assert length(result) == 2
-
-      # All names are present
-      result_names = Enum.map(result, &elem(&1, 0))
-      assert Enum.sort(result_names) == Enum.sort(names)
-
-      # Only colors from communities are used
-      identities = Enum.map(result, &elem(&1, 1))
-      assert Enum.all?(identities, &(&1 in communities))
-
-      # Both colors from communities are used
-      assert Enum.any?(identities, &(&1 == Enum.at(communities, 0)))
-      assert Enum.any?(identities, &(&1 == Enum.at(communities, 1)))
-
-      # No color appears more than once
-      identity_counts = Enum.frequencies(identities)
-
-      for {color, count} <- identity_counts do
-        assert count == 1
       end
     end
   end

--- a/test/viral_spiral/room/card_draw_test.exs
+++ b/test/viral_spiral/room/card_draw_test.exs
@@ -201,7 +201,9 @@ defmodule ViralSpiral.Room.CardDrawTest do
         # Generate dummy names
         names = Enum.map(1..n, &"player_#{&1}")
 
-        result = CardDraw.assign_player_identity(names)
+        # assign_player_identity function accepts room_communities as second argument that is only used in
+        # case of 2 players. Here, as the test is for 3 or more players, the second argument passed is nil
+        result = CardDraw.assign_player_identity(names, nil)
 
         assert length(result) == length(names)
 
@@ -225,6 +227,42 @@ defmodule ViralSpiral.Room.CardDrawTest do
         for {color, count} <- identity_counts do
           assert count <= max_allowed
         end
+      end
+    end
+  end
+
+  test "assign_player_identity_for_2_players" do
+    # Test with different combinations of 2 colors
+    test_communities = [
+      [:red, :blue],
+      [:red, :yellow],
+      [:blue, :yellow]
+    ]
+
+    for communities <- test_communities do
+      names = ["player_1", "player_2"]
+
+      result = CardDraw.assign_player_identity(names, communities)
+
+      assert length(result) == 2
+
+      # All names are present
+      result_names = Enum.map(result, &elem(&1, 0))
+      assert Enum.sort(result_names) == Enum.sort(names)
+
+      # Only colors from communities are used
+      identities = Enum.map(result, &elem(&1, 1))
+      assert Enum.all?(identities, &(&1 in communities))
+
+      # Both colors from communities are used
+      assert Enum.any?(identities, &(&1 == Enum.at(communities, 0)))
+      assert Enum.any?(identities, &(&1 == Enum.at(communities, 1)))
+
+      # No color appears more than once
+      identity_counts = Enum.frequencies(identities)
+
+      for {color, count} <- identity_counts do
+        assert count == 1
       end
     end
   end


### PR DESCRIPTION
This PR addresses issue #40. 

## Cause of the issue

- While starting the game, we are generating `room_communities`. In case of 3 or fewer players, we are randomly keeping 2 communities.
- Then, we are generating Player structs. In that, in the case of 3 players, we are assigning them each with one identity. For 2 players, we are randomly assigning 2 identities.
- Then, while assigning biases, "we are assigning them from `room_communities`", we are selecting all the room_communities except the current player's identity.

### Scenarios:
#### 2 Players:
- Randomly selected room_communities: red, blue
- While Player Creation
  - Randomly selected player identities: red, yellow
  - Selecting Biases: (room_communities) - (player's identity)
    - Red Player Biases: Blue
    - Yellow Player Biases: Red, Blue 
    
**BLUE player doesn't exist, but blue bias is still being assigned.** 

##### 3 Players:
  - Randomly selected room_communities: red, blue
  - While Player Creation
    - Randomly selected player identities: red, blue, yellow
    - Selecting Biases: (room_communities) - (player's identity)
      - Red Player Biases: Blue
      - Blue Player Biases: Red
      - Yellow Player Biases: Red, Blue
      
**There is a yellow player, but `room_communities` doesn't have a yellow community.** 

## Fixes
- For 3 players, instead of assigning 2 room communities, now all 3 communities are being assigned. 
- For 2 players, I have added a case while creating Player structs, in case of 2 players, assign them based on room_communities (that are already randomly selected) only, and not randomly take 2 out of 3.
### Test Cases
- As I have added a new parameter in the function that assigns identities to the players, there was an issue with a test case: https://github.com/tattle-made/viral-spiral/blob/447a7a2804acc32ef73ff4052b617d41646adc4b/test/viral_spiral/room/card_draw_test.exs#L197-L230
- This test case checks for 3-12 players. As the newly added parameter is only used in the case of 2 players, I have passed `nil` as the second argument in the function. 
- I have created a new test case for 2 players. 
 