### PR TITLE
fix: center join room sections in small screens

### DIFF
--- a/lib/viral_spiral_web/live/multiplayer.html.heex
+++ b/lib/viral_spiral_web/live/multiplayer.html.heex
@@ -6,7 +6,7 @@
     </p>
   </div>
   <div class="flex-grow-0 flex items-center justify-center mt-4">
-    <div id="multiplayer-room-create" class="flex flex-row gap-12 flex-wrap">
+    <div id="multiplayer-room-create" class="flex flex-row gap-12 flex-wrap justify-center">
       <div
         class="relative w-80 h-96 group cursor-pointer border border-4 border-[#3E6FF2]"
         phx-click="toggle_create_panel"


### PR DESCRIPTION
Issue resolved: #52 
Center the join rooms divs in small screens.