### PR TITLE
feat: viral spiral can also trigger if affinities reach 5

### DIFF
--- a/lib/viral_spiral/entity/player.ex
+++ b/lib/viral_spiral/entity/player.ex
@@ -120,6 +120,19 @@ defmodule ViralSpiral.Entity.Player do
     end
   end
 
+  @doc """
+  Pick an affinity whose absolute value is >= threshold.
+  Returns the affinity atom or nil if none found.
+  """
+  def viralspiral_target_affinity(%Player{} = player, threshold) do
+    target_affinity = Enum.filter(player.affinities, fn {_, v} -> abs(v) >= threshold end)
+
+    case target_affinity do
+      [] -> nil
+      x -> x |> hd() |> elem(0)
+    end
+  end
+
   defimpl ViralSpiral.Entity.Change do
     require IEx
     alias ViralSpiral.Entity.Player.Changes.CloseArticle

--- a/lib/viral_spiral/room/reducer.ex
+++ b/lib/viral_spiral/room/reducer.ex
@@ -370,12 +370,26 @@ defmodule ViralSpiral.Room.Reducer do
     set_power_change = [{state.turn, %SetPowerTrue{}}]
 
     target_bias = Player.viralspiral_target_bias(sender, viralspiral_threshold) |> IO.inspect()
-    reduce_bias_change = [{state.players[from_id], %Bias{target: target_bias, offset: -1}}]
+    target_affinity = Player.viralspiral_target_affinity(sender, viralspiral_threshold)
+
+    penalty_changes =
+      case target_bias do
+        nil ->
+          case target_affinity do
+            nil -> []
+            affinity ->
+              current = sender.affinities[affinity]
+              offset = if current > 0, do: -1, else: 1
+              [{state.players[from_id], %Affinity{target: affinity, offset: offset}}]
+          end
+        bias ->
+          [{state.players[from_id], %Bias{target: bias, offset: -1}}]
+      end
 
     all_changes =
       power_change ++
         card_pass_changes ++
-        sender_hand_change ++ hand_changes ++ set_power_change ++ reduce_bias_change
+        sender_hand_change ++ hand_changes ++ set_power_change ++ penalty_changes
 
     State.apply_changes(state, all_changes)
   end

--- a/lib/viral_spiral_web/live/multiplayer_room/state_adapter.ex
+++ b/lib/viral_spiral_web/live/multiplayer_room/state_adapter.ex
@@ -239,10 +239,20 @@ defmodule ViralSpiralWeb.MultiplayerRoom.StateAdapter do
     threshold = state.room.viral_spiral_threshold
     player = state.players[player_id]
 
+    # Enable if (a) any bias >= threshold OR (b) any affinity has |value| >= 5,
+    # and it's the current player's turn.
+    bias_enabled =
+      player.biases
+      |> Map.values()
+      |> Enum.any?(&(&1 >= threshold))
+
+    affinity_enabled =
+      player.affinities
+      |> Map.values()
+      |> Enum.any?(&(abs(&1) >= threshold))
+
     enabled =
-      Map.values(player.biases)
-      |> Enum.any?(&(&1 >= threshold)) &&
-        State.current_turn_player(state).id == player_id
+      (bias_enabled or affinity_enabled) && State.current_turn_player(state).id == player_id
 
     %{enabled: enabled}
   end


### PR DESCRIPTION
The Viral Spiral power can also be triggered when the affinities reach 5. 
