### PR TITLE
Fix/turn fake power

### DIFF
--- a/lib/viral_spiral/room/playable.ex
+++ b/lib/viral_spiral/room/playable.ex
@@ -118,6 +118,7 @@ defimpl ViralSpiral.Room.Playable, for: ViralSpiral.Canon.Card.Affinity do
   alias ViralSpiral.Entity.Player.Changes.{Clout, Affinity}
   alias ViralSpiral.Room.State
   alias ViralSpiral.Entity.Player.Map, as: PlayerMap
+  alias ViralSpiral.Entity.Room.Changes.OffsetChaos
 
   # Increase the player's affinity by 1
   # Increase player's clout by 1
@@ -177,8 +178,18 @@ defimpl ViralSpiral.Room.Playable, for: ViralSpiral.Canon.Card.Affinity do
       }
     ]
 
+    # To check in case of turn to fake power is used and the card has bias towards any communtiy.
+    bias = Map.get(card, :bias)
+
+    change_room_chaos =
+      if bias do
+        [{state.room, %OffsetChaos{offset: 1}, :chaos_current_turn_player_shared_bias_card}]
+      else
+        []
+      end
+
     current_round_player_changes ++
-      sender_changes ++ conflation_changes ++ change_clout_of_card_target
+      sender_changes ++ conflation_changes ++ change_clout_of_card_target ++ change_room_chaos
   end
 
   def keep(card, state, from) do
@@ -269,6 +280,7 @@ defimpl ViralSpiral.Room.Playable, for: ViralSpiral.Canon.Card.Topical do
   alias ViralSpiral.Room.State
   alias ViralSpiral.Entity.Player.Changes.Clout
   alias ViralSpiral.Entity.Player.Map, as: PlayerMap
+  alias ViralSpiral.Entity.Room.Changes.OffsetChaos
 
   def pass(card, %State{} = state, from_id, _to_id) do
     current_round_player_id = State.current_round_player(state).id
@@ -312,8 +324,18 @@ defimpl ViralSpiral.Room.Playable, for: ViralSpiral.Canon.Card.Topical do
           )
       end
 
+    # To check in case of turn to fake power is used and the card has bias towards any communtiy.
+    bias = Map.get(card, :bias)
+
+    change_room_chaos =
+      if bias do
+        [{state.room, %OffsetChaos{offset: 1}, :chaos_current_turn_player_shared_bias_card}]
+      else
+        []
+      end
+
     current_round_player_changes ++
-      conflation_changes ++ change_clout_of_card_target
+      conflation_changes ++ change_clout_of_card_target ++ change_room_chaos
   end
 
   def keep(_card, _state, _from) do

--- a/lib/viral_spiral/room/state_transformation.ex
+++ b/lib/viral_spiral/room/state_transformation.ex
@@ -86,8 +86,15 @@ defmodule ViralSpiral.Room.StateTransformation do
 
   def can_turn_fake(%State{} = state, %Sparse{} = card) do
     case state.dynamic_card.identity_stats[card] do
-      nil -> true
-      _ -> false
+      nil ->
+        case Canon.get_card_from_store(card) do
+          %ViralSpiral.Canon.Card.Affinity{} -> true
+          %ViralSpiral.Canon.Card.Topical{} -> true
+          _ -> false
+        end
+
+      _ ->
+        false
     end
   end
 end

--- a/lib/viral_spiral_web/live/multiplayer_room/state_adapter.ex
+++ b/lib/viral_spiral_web/live/multiplayer_room/state_adapter.ex
@@ -7,6 +7,7 @@ defmodule ViralSpiralWeb.MultiplayerRoom.StateAdapter do
   alias ViralSpiral.Entity.Turn
   alias ViralSpiral.Entity.Player.Map, as: PlayerMap
   alias ViralSpiral.Room.State
+  alias ViralSpiral.Room.StateTransformation
   alias ViralSpiral.Room.Template
 
   def make_game_room(%State{} = state, player_name) do
@@ -71,7 +72,7 @@ defmodule ViralSpiralWeb.MultiplayerRoom.StateAdapter do
           |> Enum.map(fn id -> %{id: id, name: state.players[id].name} end),
         source: make_source(state.players[player.id], &1),
         can_mark_as_fake: can_mark_as_fake?(state.turn),
-        can_turn_fake: &1.veracity == true
+        can_turn_fake: StateTransformation.can_turn_fake(state, Sparse.new(&1.id, &1.veracity))
       }
     )
   end
@@ -116,11 +117,12 @@ defmodule ViralSpiralWeb.MultiplayerRoom.StateAdapter do
     alias ViralSpiral.Canon.DynamicCard
 
     headline = card.headline
+    fake_headline = card.fake_headline
     sparse_card = Sparse.new(card.id, card.veracity)
 
     case dynamic_card.identity_stats[sparse_card] do
       nil -> headline
-      stats -> DynamicCard.patch(headline, stats)
+      stats -> DynamicCard.patch(fake_headline, stats)
     end
   end
 


### PR DESCRIPTION
This PR implements changes for the "turn to fake" power.

- The power is enabled in the multiplayer mode as well. Earlier, it was only working in the designer mode. 
- The TGB now goes down when a manufactured card is passed. 
- Earlier, the power option was coming on the bias cards as well (though it was not getting implemented even after clicking & there was an error every time). This is fixed. Now, the "turn to fake" option only comes on Affinity and Topical cards.  