### PR TITLE
fix: disappearance of voting modal due to flash auto-hide

### DIFF
--- a/assets/js/flash.js
+++ b/assets/js/flash.js
@@ -1,19 +1,26 @@
 export const FlashAutoHide = {
     mounted() {
+        console.log("Flash auto hide hook mounted", this.el);
         const msAttr = this.el.getAttribute("data-timeout-ms");
-        const timeout = parseInt(msAttr || "0", 10);
+        const timeout = parseInt(msAttr || "4000", 10);
         if (!Number.isFinite(timeout) || timeout <= 0) return;
 
-        this.timer = setTimeout(() => {
-            // Trigger the same behavior as manual close by clicking the element
-            // which has a phx-click to clear and hide itself
-            this.el.click();
+        this.el.style.transition = 'opacity 0.5s ease-out';
+
+        this.hideTimer = setTimeout(() => {
+
+            this.el.style.opacity = '0';
+
+            this.removeTimer = setTimeout(() => {
+                if (this.el && this.el.parentNode) {
+                    this.el.parentNode.removeChild(this.el);
+                }
+            }, 500);
         }, timeout);
     },
+
     destroyed() {
-        if (this.timer) {
-            clearTimeout(this.timer);
-            this.timer = null;
-        }
+        if (this.hideTimer) clearTimeout(this.hideTimer);
+        if (this.removeTimer) clearTimeout(this.removeTimer);
     }
 };


### PR DESCRIPTION
This PR fixes the following problem:
- The voting modal for canceling a player disappeared automatically after 4 seconds. The behaviour was repeating even after refreshing the page. 
- This was happening due to a hook created to auto-hide the flash notifications. In the hook, after a certain time, the click event occurs to hide the flash notification, which in turn hides the cancellation modal (the behaviour that clicking anywhere outside the modal will close it).
- This has been fixed by updating the working of the existing auto-hide flash notification hook.