### PR TITLE
feat: add tooltip component and use it to describe player properties

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -35,6 +35,7 @@ import Player from "./player";
 import { CarouselHook } from "./carousel";
 import { RoomLinkCopyClipboardHook } from "./room-link-copy-clipboard";
 import PopoverHook from "./popover";
+import TooltipHook from "./tooltip";
 
 let Hooks = {
   CalendarHook,
@@ -47,7 +48,8 @@ let Hooks = {
   CarouselHook,
   RoomLinkCopyClipboardHook,
   FlashAutoHide,
-  PopoverHook
+  PopoverHook,
+  TooltipHook
 };
 
 let csrfToken = document

--- a/assets/js/tooltip.js
+++ b/assets/js/tooltip.js
@@ -1,0 +1,39 @@
+import { Tooltip as FlowbiteTooltip } from "flowbite";
+
+const TooltipHook = {
+  mounted() {
+    this.initializeTooltip();
+  },
+
+  updated() {
+    if (this.tooltip) this.tooltip.destroy();
+    this.initializeTooltip();
+  },
+
+  destroyed() {
+    if (this.tooltip) this.tooltip.destroy();
+  },
+
+  initializeTooltip() {
+    const triggerEl = this.el.querySelector("[data-tooltip-target]");
+    const targetId = triggerEl?.getAttribute("data-tooltip-target");
+    const targetEl = targetId ? document.querySelector(`#${targetId}`) : null;
+
+    if (triggerEl && targetEl) {
+      const options = {
+        placement: triggerEl.getAttribute("data-placement") || "top",
+        triggerType: "hover",
+        offset: 10,
+      };
+
+      this.tooltip = new FlowbiteTooltip(targetEl, triggerEl, options, {
+        id: targetId,
+        override: true,
+      });
+    } else {
+      console.error("Could not find tooltip target element");
+    }
+  },
+};
+
+export default TooltipHook;

--- a/lib/viral_spiral_web/components/core_components.ex
+++ b/lib/viral_spiral_web/components/core_components.ex
@@ -770,7 +770,7 @@ defmodule ViralSpiralWeb.CoreComponents do
       <div
         id={"tooltip-light-#{@id}-#{@random_number}"}
         role="tooltip"
-        class="absolute min-w-[12rem] z-10 invisible inline-block text-center px-4 py-4 text-xs font-medium text-gray-900 bg-white border border-gray-300 rounded-lg shadow-xs opacity-0 tooltip"
+        class="absolute min-w-[12rem] z-10 invisible inline-block px-4 py-4 text-left text-xs font-medium text-gray-900 bg-white border border-gray-300 rounded-lg shadow-xs opacity-0 tooltip"
       >
         <%= render_slot(@tooltip_content) %>
         <div class="tooltip-arrow" data-popper-arrow></div>

--- a/lib/viral_spiral_web/components/core_components.ex
+++ b/lib/viral_spiral_web/components/core_components.ex
@@ -747,4 +747,35 @@ defmodule ViralSpiralWeb.CoreComponents do
     </div>
     """
   end
+
+  attr :id, :string, required: true
+  # attr :content, :string, required: true
+  slot :inner_block, required: true
+  slot :tooltip_content, required: true
+
+  def info_tooltip(assigns) do
+    random_number = :rand.uniform(10000)
+    assigns = assign(assigns, random_number: random_number)
+
+    ~H"""
+    <div id={"tooltip-container-#{@id}-#{@random_number}"} phx-hook="TooltipHook">
+      <div
+        data-tooltip-target={"tooltip-light-#{@id}-#{@random_number}"}
+        data-tooltip-style="light"
+        type="button"
+      >
+        <%= render_slot(@inner_block) %>
+      </div>
+
+      <div
+        id={"tooltip-light-#{@id}-#{@random_number}"}
+        role="tooltip"
+        class="absolute min-w-[12rem] z-10 invisible inline-block text-center px-4 py-4 text-xs font-medium text-gray-900 bg-white border border-gray-300 rounded-lg shadow-xs opacity-0 tooltip"
+      >
+        <%= render_slot(@tooltip_content) %>
+        <div class="tooltip-arrow" data-popper-arrow></div>
+      </div>
+    </div>
+    """
+  end
 end

--- a/lib/viral_spiral_web/components/molecules.ex
+++ b/lib/viral_spiral_web/components/molecules.ex
@@ -244,8 +244,8 @@ defmodule ViralSpiralWeb.Molecules do
           <.info_tooltip id={"clout-#{@player.id}"}>
             <span class="text-sm">Clout</span>
             <:tooltip_content>
+              <h2 class="text-lg font-semibold">Clout</h2>
               <p><strong>Clout</strong> measures a <strong>Player's influence</strong>.</p>
-              <br />
               <p>At 10 Clout → <strong>Victory!</strong></p>
             </:tooltip_content>
           </.info_tooltip>
@@ -260,8 +260,8 @@ defmodule ViralSpiralWeb.Molecules do
             <.info_tooltip id={"biases-info-#{@player.id}"}>
               <p class="text-sm font-semibold text-textcolor-light cursor-pointer">Biases</p>
               <:tooltip_content>
+                <h2 class="text-lg font-semibold">Biases</h2>
                 <p>Bias ≥ 2 → Unlocks <strong>Manufacture Fake Card</strong> power</p>
-                <br />
                 <p>Bias ≥ 4 → Unlocks <strong>Viral Spiral</strong> power</p>
               </:tooltip_content>
             </.info_tooltip>
@@ -276,8 +276,8 @@ defmodule ViralSpiralWeb.Molecules do
           <.info_tooltip id={"affinities-info-#{@player.id}"}>
             <p class="text-sm font-semibold text-textcolor-light cursor-pointer">Affinities</p>
             <:tooltip_content>
+              <h2 class="text-lg font-semibold">Affinities</h2>
               <p>Affinity ±2 → Unlocks <strong>Cancel Player</strong> power</p>
-              <br />
               <p>Affinity ±4 → Unlocks <strong>Viral-Spiral</strong> power</p>
             </:tooltip_content>
           </.info_tooltip>

--- a/lib/viral_spiral_web/components/molecules.ex
+++ b/lib/viral_spiral_web/components/molecules.ex
@@ -2,6 +2,7 @@ defmodule ViralSpiralWeb.Molecules do
   alias ViralSpiral.Affinity
   alias ViralSpiral.Bias
   use ViralSpiralWeb, :html
+  import ViralSpiralWeb.CoreComponents
 
   defp card_url(file_name) do
     # Because of a mistake made by designers, all filenames have a space in it
@@ -28,13 +29,16 @@ defmodule ViralSpiralWeb.Molecules do
           <div class="mt-2">
             <img class="w-full h-80 object-contain" src={card_url(@card.image)} />
           </div>
-          <p :if={!@in_spec_mode} class="absolute z-4 bottom-0 px-2 py-2 mx-4 text-sm/4 bg-zinc-200 bg-opacity-95 rounded-md text-xs/1">
+          <p
+            :if={!@in_spec_mode}
+            class="absolute z-4 bottom-0 px-2 py-2 mx-4 text-sm/4 bg-zinc-200 bg-opacity-95 rounded-md text-xs/1"
+          >
             <%= @card.headline %>
           </p>
         </div>
       </div>
 
-      <div class="flex flex-col py-2" >
+      <div class="flex flex-col py-2">
         <%= if !is_nil(@card.pass_to) and length(@card.pass_to) != 0 and !@in_spec_mode do %>
           <div class="px-2 flex flex-row gap-2 align-center">
             <span class="text-sm mb-1 self-center">Pass to</span>
@@ -60,7 +64,7 @@ defmodule ViralSpiralWeb.Molecules do
           </div>
         <% end %>
 
-        <div class="mt-2 flex flex-row gap-2 flex-wrap px-2" :if={!@in_spec_mode}>
+        <div :if={!@in_spec_mode} class="mt-2 flex flex-row gap-2 flex-wrap px-2">
           <div class="">
             <button
               phx-click={
@@ -232,11 +236,19 @@ defmodule ViralSpiralWeb.Molecules do
     ~H"""
     <div class="flex flex-row h-fit w-fit p-2 gap-2 border border-gray-400 rounded-md bg-neutral-3">
       <div class="flex flex-col justify-between gap-1">
-        <div class={"h-12 w-12 #{bg_class(@player.identity)} border border-2 rounded-md overflow-hidden"}>
+        <div class={"h-12 w-12 #{bg_class(@player.identity)} border-2 rounded-md overflow-hidden"}>
           <img class="h-12 w-12 object-fit" src={dp_url(@player.id)} />
         </div>
-        <div class="text-textcolor-light font-extrabold text-2xl leading-none ml-2 mb-3">
+        <div class="text-textcolor-light font-extrabold text-xl leading-none ml-2 mb-3 text-center">
           <%= @player.clout %>
+          <.info_tooltip id={"clout-#{@player.id}"}>
+            <span class="text-sm">Clout</span>
+            <:tooltip_content>
+              <p><strong>Clout</strong> measures a <strong>Player's influence</strong>.</p>
+              <br />
+              <p>At 10 Clout → <strong>Victory!</strong></p>
+            </:tooltip_content>
+          </.info_tooltip>
         </div>
       </div>
       <div>
@@ -245,7 +257,14 @@ defmodule ViralSpiralWeb.Molecules do
         </div>
         <div class="flex flex-row gap-4">
           <div class="flex flex-row items-center gap-2">
-            <p class="text-sm font-semibold text-textcolor-light">Biases</p>
+            <.info_tooltip id={"biases-info-#{@player.id}"}>
+              <p class="text-sm font-semibold text-textcolor-light cursor-pointer">Biases</p>
+              <:tooltip_content>
+                <p>Bias ≥ 2 → Unlocks <strong>Manufacture Fake Card</strong> power</p>
+                <br />
+                <p>Bias ≥ 4 → Unlocks <strong>Viral Spiral</strong> power</p>
+              </:tooltip_content>
+            </.info_tooltip>
             <%= for {bias, value} <- @player.biases do %>
               <div class={"w-8 h-8 rounded-full flex items-center justify-center text-s text-textcolor-light #{bias_color_class(bias)}"}>
                 <%= value %>
@@ -254,7 +273,14 @@ defmodule ViralSpiralWeb.Molecules do
           </div>
         </div>
         <div class="flex flex-row items-center gap-2 mt-2">
-          <p class="text-sm font-semibold text-textcolor-light">Affinities</p>
+          <.info_tooltip id={"affinities-info-#{@player.id}"}>
+            <p class="text-sm font-semibold text-textcolor-light cursor-pointer">Affinities</p>
+            <:tooltip_content>
+              <p>Affinity ±2 → Unlocks <strong>Cancel Player</strong> power</p>
+              <br />
+              <p>Affinity ±4 → Unlocks <strong>Viral-Spiral</strong> power</p>
+            </:tooltip_content>
+          </.info_tooltip>
           <div class="flex flex-row gap-2 items-center">
             <%= for {affinity, value} <- @player.affinities do %>
               <div class="relative w-9 h-9">

--- a/lib/viral_spiral_web/live/multiplayer_room.html.heex
+++ b/lib/viral_spiral_web/live/multiplayer_room.html.heex
@@ -28,16 +28,15 @@
             </div>
           </:content>
         </.popover>
-       <.info_tooltip id="game-chaos">
+        <.info_tooltip id="game-chaos">
           <p class="bg-fuchsia-950 p-2 rounded-lg text-fuchsia-100 self-start cursor-pointer">
             <span>Chaos Countdown: </span><%= 10 - @state.room.chaos %>
           </p>
           <:tooltip_content>
-          <p>When Chaos Coutdown reaches 0 → <strong>The world ends</strong></p>
-          
+            <h2 class="text-lg font-semibold">Chaos Countdown</h2>
+            <p>When Chaos Coutdown reaches 0 → <strong>The world ends</strong></p>
           </:tooltip_content>
-         
-       </.info_tooltip>
+        </.info_tooltip>
       </div>
     </div>
 

--- a/lib/viral_spiral_web/live/multiplayer_room.html.heex
+++ b/lib/viral_spiral_web/live/multiplayer_room.html.heex
@@ -28,9 +28,16 @@
             </div>
           </:content>
         </.popover>
-        <p class="bg-fuchsia-950 p-2 rounded-lg text-fuchsia-100 self-start">
-          <%= 10 - @state.room.chaos %>
-        </p>
+       <.info_tooltip id="game-chaos">
+          <p class="bg-fuchsia-950 p-2 rounded-lg text-fuchsia-100 self-start cursor-pointer">
+            <span>Chaos Countdown: </span><%= 10 - @state.room.chaos %>
+          </p>
+          <:tooltip_content>
+          <p>When Chaos Coutdown reaches 0 → <strong>The world ends</strong></p>
+          
+          </:tooltip_content>
+         
+       </.info_tooltip>
       </div>
     </div>
 


### PR DESCRIPTION
Added a new Tooltip component and used it to display information of different player/game properties on hovering. 

Screen recording:
[Screencast from 2025-10-07 19-22-11.webm](https://github.com/user-attachments/assets/cda74f3b-9e20-4636-98f6-9fb338645cce)


