### PR TITLE
feat: add current turn player name to card

### DIFF
--- a/lib/viral_spiral_web/components/molecules.ex
+++ b/lib/viral_spiral_web/components/molecules.ex
@@ -19,14 +19,18 @@ defmodule ViralSpiralWeb.Molecules do
   attr :can_turn_fake, :boolean, required: true
   attr :can_use_power, :boolean, required: true
   attr :in_spec_mode, :boolean, default: false
+  attr :current_turn_player_name, :string, default: nil
 
   def card(assigns) do
     ~H"""
     <div class="border-2 border-solid border-zinc-600 w-fit rounded-md bg-slate-50 flex flex-col gap-2 m-2">
       <!-- For Mobile -->
       <div class="flex-1">
+        <p :if={@current_turn_player_name} class="text-sm ml-1">
+          <strong>Turn:</strong> <%= @current_turn_player_name %>
+        </p>
         <div class="relative w-full h-80 flex flex-col gap-2">
-          <div class="mt-2">
+          <div class={"#{if @current_turn_player_name, do: "", else: "mt-2"}"}>
             <img class="w-full h-80 object-contain" src={card_url(@card.image)} />
           </div>
           <p

--- a/lib/viral_spiral_web/live/multiplayer_room.html.heex
+++ b/lib/viral_spiral_web/live/multiplayer_room.html.heex
@@ -66,6 +66,7 @@
           from={@state.me.id}
           can_turn_fake={@state.power_turn_fake.enabled}
           can_use_power={@state.can_use_power}
+          current_turn_player_name={@state.current_turn_player.name}
         />
       </div>
     </div>

--- a/lib/viral_spiral_web/live/multiplayer_room/state_adapter.ex
+++ b/lib/viral_spiral_web/live/multiplayer_room/state_adapter.ex
@@ -41,8 +41,19 @@ defmodule ViralSpiralWeb.MultiplayerRoom.StateAdapter do
           }
         end),
       others: make_others(state, other_players),
-      current_holder_name: make_current_holder_text(state)
+      current_holder_name: make_current_holder_text(state),
+      current_turn_player: make_turn_player(state)
     }
+  end
+
+  def make_turn_player(%State{} = state) do
+    round = state.round
+    # Order of players (list)
+    order = round.order
+    current_player_index = round.current
+    current_turn_player_id = Enum.at(order, current_player_index)
+    current_turn_player = state.players[current_turn_player_id]
+    %{id: current_turn_player_id, name: current_turn_player.name}
   end
 
   defp make_me(%State{} = state, player) do


### PR DESCRIPTION
This PR adds the current turn player's name to the top of the card.