### PR TITLE
feat: add plausible custom events for game start and end

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -36,6 +36,7 @@ import { CarouselHook } from "./carousel";
 import { RoomLinkCopyClipboardHook } from "./room-link-copy-clipboard";
 import PopoverHook from "./popover";
 import TooltipHook from "./tooltip";
+import { EndGameHook } from "./endgame";
 
 let Hooks = {
   CalendarHook,
@@ -49,7 +50,8 @@ let Hooks = {
   RoomLinkCopyClipboardHook,
   FlashAutoHide,
   PopoverHook,
-  TooltipHook
+  TooltipHook,
+  EndGameHook
 };
 
 let csrfToken = document

--- a/assets/js/endgame.js
+++ b/assets/js/endgame.js
@@ -1,0 +1,14 @@
+export const EndGameHook = {
+    mounted() {
+        // console.log("EndGameHook mounted")
+        this.handleEvent("send_endgame_metric", data => {
+            // console.log("inside metric hook")
+            // console.log(data)
+            
+            plausible('Game End', {props: {room: data.room}})
+        })
+
+    
+    },
+    updated(){}
+}

--- a/lib/viral_spiral_web/live/multiplayer_room.ex
+++ b/lib/viral_spiral_web/live/multiplayer_room.ex
@@ -72,7 +72,13 @@ defmodule ViralSpiralWeb.MultiplayerRoom do
     gen_state = GenServer.call(room_gen, action)
     room_state = StateAdapter.make_game_room(gen_state, player_name)
     notification_text = Notification.generate_notification(gen_state, "pass_to", params)
-    socket = socket |> assign(:state, room_state) |> maybe_put_end_banner(room_state)
+
+    socket =
+      socket
+      |> assign(:state, room_state)
+      |> maybe_put_end_banner(room_state)
+      |> maybe_send_endgame_metric(room_state)
+
     PubSub.broadcast(ViralSpiral.PubSub, "multiplayer-room:#{room_name}", {:new_action})
 
     PubSub.broadcast(
@@ -205,7 +211,7 @@ defmodule ViralSpiralWeb.MultiplayerRoom do
     notification_text =
       Notification.generate_notification(gen_state, "initiate_viral_spiral", params)
 
-    socket = socket |> assign(:state, room_state)
+    socket = socket |> assign(:state, room_state) |> maybe_send_endgame_metric(room_state)
     PubSub.broadcast(ViralSpiral.PubSub, "multiplayer-room:#{room_name}", {:new_action})
 
     PubSub.broadcast(

--- a/lib/viral_spiral_web/live/multiplayer_waiting_room.ex
+++ b/lib/viral_spiral_web/live/multiplayer_waiting_room.ex
@@ -79,7 +79,7 @@ defmodule ViralSpiralWeb.MultiplayerWaitingRoom do
         </div>
 
         <button
-          class="w-full bg-fuchsia-800 hover:bg-fuchsia-500 px-4 py-2 rounded-md text-slate-50"
+          class={"w-full bg-fuchsia-800 hover:bg-fuchsia-500 px-4 py-2 rounded-md text-slate-50 plausible-event-name=Start+Game plausible-event-room=#{@room_name}"}
           phx-click="start_game"
         >
           Start Game

--- a/lib/viral_spiral_web/live/utils.ex
+++ b/lib/viral_spiral_web/live/utils.ex
@@ -4,6 +4,11 @@ defmodule ViralSpiralWeb.Utils do
     LiveView.push_event(socket, "show_popup", %{message: msg})
   end
 
+  def send_endgame_metric(socket, room_name) do
+    alias Phoenix.LiveView
+    LiveView.push_event(socket, "send_endgame_metric", %{room: room_name})
+  end
+
   def maybe_put_end_banner(socket, room_state) do
     case room_state.room.state do
       :over ->
@@ -12,6 +17,18 @@ defmodule ViralSpiralWeb.Utils do
         else
           put_banner(socket, "Game over")
         end
+
+      _ ->
+        socket
+    end
+  end
+
+  def maybe_send_endgame_metric(socket, room_state) do
+    room_name = room_state.room.name
+
+    case room_state.room.state do
+      :over ->
+        send_endgame_metric(socket, room_name)
 
       _ ->
         socket


### PR DESCRIPTION
Add Plausible custom events for when a game starts and when a game ends. 

The event names are "Start Game" and "Game End". The room's name will be sent to these events. 

In the plausible Viral Spiral's dashboard, we would need to create 2 custom event goals with the above-mentioned event names. Ref: https://plausible.io/docs/custom-event-goals
